### PR TITLE
fix parent pom version for code deposite

### DIFF
--- a/bonita-connector-ldap-def/pom.xml
+++ b/bonita-connector-ldap-def/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.bonitasoft.connectors</groupId>
         <artifactId>bonita-connector-ldap</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
 
     <artifactId>bonita-connector-ldap-def</artifactId>

--- a/bonita-connector-ldap-impl/pom.xml
+++ b/bonita-connector-ldap-impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.bonitasoft.connectors</groupId>
         <artifactId>bonita-connector-ldap</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
 
     <artifactId>bonita-connector-ldap-impl</artifactId>


### PR DESCRIPTION
We changed the parent version (2 years ago..), so children should reference the parent in the correct version, else it doesn't work offline.