### PR TITLE
chore(java 17): Compile with Java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
        fetch-depth: 0
        
     - name: Setup Java
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'temurin'
         cache: 'maven'
 

--- a/.github/workflows/createRelease.yml
+++ b/.github/workflows/createRelease.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Release connector
-        uses: bonitasoft/action-release-connector@1.0.0
+        uses: bonitasoft/action-release-connector@2.0.0
         id: release-connector
         with:
           release-version: ${{ github.event.inputs.version }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ __Clone__ or __fork__ this repository, then at the root of the project run:
 
 `./mvnw`
 
+## Test
+
+In order to use this connector, you need to have an LDAP server configured.
+You can find instructions to deploy an LDAP server with Docker [here](https://docs.digital.ai/bundle/devops-deploy-version-v.22.2/page/deploy/how-to/setup-and-configuration-LDAP-with-deploy.html).<br>
+(Adapt `dc=xl,dc=com` and `-e LDAP_ORGANISATION="XL" -e LDAP_DOMAIN="xl.com"` to use `dc=bonita,dc=org` and `-e LDAP_ORGANISATION="bonita" -e LDAP_DOMAIN="bonita.org"` instead if you want to use the ldif file bellow)
+
+To initialize your LDAP server with test data, you can find an example ldif file to import on [bonita-ldap-synchronizer](https://github.com/bonitasoft/bonita-ldap-synchronizer/blob/dev/example/docker/ldap/openldap/resources/01_ldap_data.ldif).
+
+To help you fill the LDAP search wizard in Bonita Studio, you can use the "search" page of phpLDAPadmin which perform similar requests.
+
+### Troubleshooting
+
+If you get an error such as `[LDAP: error code 34 - invalid DN]`<br>
+Make sure you use the full username such as `cn=admin,dc=bonita,dc=org`
+
+I you get an exception `java.lang.ClassCastException: class java.util.ArrayList cannot be cast to class java.lang.String (java.util.ArrayList and java.lang.String are in module java.base of loader 'bootstrap')`<br>
+Your affected variable must be of type `Java Object` with class `java.util.List`
+
 ## Release
 
 In order to create a new release: 


### PR DESCRIPTION
Use version 2.0.0 of release action which compiles with Java 17

11 compatibility is needed for the connector to be compatible with maintenance versions

Closes [BPM-28](https://bonitasoft.atlassian.net/browse/BPM-28)

[BPM-28]: https://bonitasoft.atlassian.net/browse/BPM-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ