### PR TITLE
chore(ci): add Claude Code review workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,79 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [ opened, labeled ]
+  issue_comment:
+    types: [ created ]
+
+jobs:
+  claude-review:
+    if: |
+      (
+        (github.event_name == 'pull_request' && github.event.action == 'opened') ||
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude review')) ||
+        (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'ask-claude-review')
+      ) && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Get PR number
+        id: pr-number
+        run: |
+          if [ "${{ github.event_name }}" == "issue_comment" ]; then
+            echo "pr_number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+          else
+            echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          fi
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ORGANIZATION_ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ steps.pr-number.outputs.pr_number }}
+
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+
+            POST YOUR REVIEW BY UPDATING AN EXISTING CODE REVIEW COMMENT if exists, or by CREATING A NEW COMMENT otherwise:
+
+            Step 1 - Find existing Claude review comment (REQUIRED):
+            COMMENT_ID=$(gh pr view ${{ steps.pr-number.outputs.pr_number }} --json comments --jq '.comments[] | select(.body | contains("## Claude Code Review")) | .id' | head -1)
+
+            Step 2 - Create your review markdown:
+            - Start with "## Claude Code Review" header (REQUIRED for identification)
+            - Add timestamp: "**Last updated:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+            - Include review counter if updating: "**Review iteration:** #N"
+            - Then provide your detailed review
+
+            Step 3 - ALWAYS update existing comment if it exists (MANDATORY):
+            if [ -n "$COMMENT_ID" ]; then
+              gh pr comment ${{ steps.pr-number.outputs.pr_number }} --edit-last --body "<your-review-markdown>"
+              echo "Updated existing review comment ID: $COMMENT_ID"
+            else
+              gh pr comment ${{ steps.pr-number.outputs.pr_number }} --body "<your-review-markdown>"
+              echo "Created initial review comment"
+            fi
+
+            IMPORTANT RULES:
+            1. NEVER create a new Claude Code Review comment if one exists - ALWAYS edit the existing one
+            2. Always start with "## Claude Code Review" for identification
+            3. Include timestamp to show when review was last updated
+            4. Prevent unwanted GitHub auto-linking and mentions
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,38 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ORGANIZATION_ANTHROPIC_API_KEY }}
+          additional_permissions: |
+            actions: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,100 @@
+# Bonita LDAP Connector
+
+## Project Overview
+
+- **Name**: Bonita LDAP Connector
+- **Artifact**: `org.bonitasoft.connectors:bonita-connector-ldap`
+- **Version**: 1.2.2-SNAPSHOT
+- **Description**: Bonita connector that performs LDAP directory search operations. Supports LDAP, LDAPS (SSL), and TLS protocols, paged results, and configurable scopes/filters.
+- **License**: GPL-2.0
+- **Tech stack**: Java 11, Maven, Bonita Engine 7.13.0, Java JNDI (`javax.naming`), SLF4J, JUnit 5, AssertJ
+
+## Build Commands
+
+```bash
+# Full build with tests (default goal)
+./mvnw clean verify
+
+# Skip tests
+./mvnw clean verify -DskipTests
+
+# Run tests only
+./mvnw test
+
+# Check license headers (runs at validate phase automatically)
+./mvnw validate
+
+# Apply/format license headers
+./mvnw license:format
+
+# Package connector ZIP
+./mvnw clean package
+
+# Deploy to Maven Central (requires GPG key)
+./mvnw clean deploy -Pdeploy
+```
+
+The build produces:
+- `target/bonita-connector-ldap-<version>.jar`
+- `target/bonita-connector-ldap-<version>-*.zip` — Bonita connector assembly
+
+## Architecture
+
+### Class hierarchy
+
+```
+AbstractConnector (bonita-common)
+  └── LdapConnector          # Single connector; all LDAP search logic
+
+LdapAttribute               # Simple value object: attributeId + value (String)
+LdapProtocol (enum)         # LDAP | LDAPS | TLS
+LdapScope (enum)            # BASE | ONELEVEL | SUBTREE  →  maps to SearchControls constants
+LdapDereferencingAlias (enum) # ALWAYS | FINDING | NEVER | SEARCHING
+```
+
+### Key patterns
+
+- **Custom `setInputParameters()`**: `LdapConnector` overrides `setInputParameters()` to eagerly parse and type-convert all connector inputs (port, scope, protocol, derefAliases) into strongly-typed fields. This means the connector's fields are ready before `validateInputParameters()` runs.
+- **Paged vs. non-paged search**: `executeBusinessLogic()` branches on `pageSize > 0` to call either `doPagedSearch()` (LDAP paged results control) or `doNonPagedSearch()`.
+- **TLS upgrade**: When protocol is `TLS`, a `StartTlsRequest` is sent over the initial plain LDAP context before credentials are set.
+- **Output**: `ldapAttributeList` — `List<List<LdapAttribute>>`, one inner list per matching DN.
+- **License check**: `license-maven-plugin` enforces the GPL header on all `.java` files at `validate`.
+
+## Testing Strategy
+
+- Framework: JUnit 5 (Jupiter) + AssertJ
+- `LdapConnectorTest` covers input validation (all error conditions), parameter parsing (enum conversions, port ranges), and the `setInputParameters()` mapping.
+- No integration test against a real LDAP server is included; tests are purely unit-level.
+- Coverage enforced via JaCoCo.
+- SonarCloud project key: `bonitasoft_bonita-connector-ldap`.
+
+## Commit Message Format
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <short description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Common types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `ci`.
+
+Examples:
+```
+feat: support paged LDAP search results
+fix: validate port range correctly (0-65535)
+chore: bump JUnit Jupiter to 5.11.0
+```
+
+## Release Process
+
+1. Remove `-SNAPSHOT` from `version` in `pom.xml`.
+2. Update `connector-definition-version` if the connector definition changed.
+3. Commit: `chore: release X.Y.Z`.
+4. Tag: `git tag X.Y.Z`.
+5. Deploy to Maven Central: `./mvnw clean deploy -Pdeploy` (requires GPG key and Central credentials in `~/.m2/settings.xml`).
+6. Push tag: `git push origin X.Y.Z`.
+7. Bump to next `-SNAPSHOT` and commit: `chore: prepare next development iteration`.


### PR DESCRIPTION
## Summary
- Add automated Claude Code PR review workflow (`claude-code-review.yml`)
- Add interactive `@claude` workflow (`claude.yml`)
- Add project-specific `CLAUDE.md` for AI-assisted development context

## Details
- Auto-review triggers on PR open, `@claude review` comment, or `ask-claude-review` label
- Interactive mode responds to `@claude` mentions in issues, PR comments, and reviews
- Uses org-level `ORGANIZATION_ANTHROPIC_API_KEY` secret
- Based on the mature workflow from `bonita-connector-ai`

## Test plan
- [ ] Verify workflows appear in Actions tab after merge
- [ ] Test auto-review by opening a test PR
- [ ] Test interactive mode with `@claude` comment

Generated with [Claude Code](https://claude.com/claude-code)